### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Stories in Ready](https://badge.waffle.io/hmrc/hmrc.github.io.png?label=ready&title=Ready)](https://waffle.io/hmrc/hmrc.github.io)
 # hmrc.github.io
 Information about the HMRC GitHub organisation, repositories and approaches to software


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/hmrc/hmrc.github.io

This was requested by a real person (user duncancrawford) on waffle.io, we're not trying to spam you.