### PR TITLE
Remove some gov.uk styles and replace with minimal design

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 defaults:
   -
     scope:
-      paht: ""
+      path: ""
     values:
       layout: govuk_template

--- a/_config.yml
+++ b/_config.yml
@@ -3,4 +3,4 @@ defaults:
     scope:
       path: ""
     values:
-      layout: govuk_template
+      layout: default

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,11 +1,7 @@
 <!-- HEADER -->
 <div id="header_wrap" class="outer">
   <header class="inner">
-    <a id="forkme_banner" href="https://github.com/hmrc">HMRC on GitHub</a>
-      <p>
-          <img style="float: left" src="/images/hmrc_crest_200px.png"/>
+    <a id="forkme_banner" href="https://github.com/hmrc">See HMRC's code on GitHub</a>
           <h1 id="project_title">HMRC on GitHub</h1>
-      </p>
-      <h2 id="project_tagline">Information about HMRC on GitHub</h2>
   </header>
 </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,12 +5,16 @@
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
     <meta name="description" content="Hmrc.GitHub.io : Information about the HMRC GitHub organisation, repositories and approaches to software">
 
+    <link href='http://fonts.googleapis.com/css?family=Oswald' rel='stylesheet' type='text/css'>
+
     <link rel="stylesheet" type="text/css" media="screen" href="/stylesheets/stylesheet.css">
 
     <title>Hmrc.GitHub.io</title>
   </head>
 
   <body>
+    <div class="page-wrapper">
+
     {% include header.html %}
 
     <!-- MAIN CONTENT -->
@@ -20,6 +24,7 @@
       </section>
     </div>
 
-    {% include footer.html %}
+      {% include footer.html %}
+    </div> <!-- page wrapper ends -->
   </body>
 </html>

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -17,3 +17,42 @@
     padding: 0 30px 2em 30px;
   }
 }
+
+@media (min-width: 641px) {
+    .page-wrapper {
+      float: none;
+      width: 70%;
+      margin: 0 auto;
+  }  
+}
+
+body {
+  font-family: HelveticaNeue;
+}
+
+h1, h2, h3, h4 {
+  font-family: 'Oswald';
+}
+
+.inner {
+  display: block; 
+  margin: 0 auto;
+  width: 80%;
+}
+
+h1#project_title {
+  font-size: 3em;
+  line-height: 2em;
+  text-align: center;
+}
+
+a {
+  text-decoration: none;
+  color: olive;
+}
+
+a:hover {
+  border-bottom: 1px dotted olive;
+}
+
+


### PR DESCRIPTION
See the commit message for the second commit but tl;dr we were using some gov.uk style elements that we shouldn't be (images and fonts) so I moved us back to a more minimal style.

I'm going to carry on working on this but maybe I'll pick up with @rpowis and @duncancrawford next week to talk about what we want to do.