### PR TITLE
Remove "Iron Man" as name of permissions schema

### DIFF
--- a/_posts/development-documentation/2015-01-29-coding-in-the-open-manual.md
+++ b/_posts/development-documentation/2015-01-29-coding-in-the-open-manual.md
@@ -24,7 +24,7 @@ Hopefully the repositories that we produce are of use to other Open Source proje
 
 HMRC is a [GitHub.com public organisation](https://www.github.com/hmrc). The expectation is that every source code repository - a library, a frontend, a service - will be open-sourced on GitHub.com. When a repository contains security-critical code and/or configuration it is refactored to be as small a component as possible, with the non-critical majority open-sourced as a separate repository.
 
-The HMRC on GitHub organisation is composed of delivery teams currently working within HMRC on MDTP infrastructure and services. The ['Iron Man' improved permissions model](https://github.com/orgs/improved-permissions) is used so that the organisation is managed centrally,  delivery teams are managed by delivery team leads, and repositories are managed by delivery team members.
+The HMRC on GitHub organisation is composed of delivery teams currently working within HMRC on MDTP infrastructure and services. The [improved permissions model](https://github.com/orgs/improved-permissions) is used so that the organisation is managed centrally,  delivery teams are managed by delivery team leads, and repositories are managed by delivery team members.
 
 
 #### Supplementary Documentation


### PR DESCRIPTION
I've never heard anyone refer to it in this way. GitHub does not refer to it like this on their page and a google search cannot find anyone using this terminology.