### PR TITLE
run 11ty via it's binary rather than npx <packagename>

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "hmrc-engineering-guidance",
   "scripts": {
-    "serve": "npx @11ty/eleventy --serve",
-    "build": "npx @11ty/eleventy"
+    "serve": "eleventy --serve",
+    "build": "eleventy"
   },
   "dependencies": {
     "@11ty/eleventy": "^3.0.0",


### PR DESCRIPTION
we were using the convention that 11ty has in it's templates of running it's commands using `npx <packagename>`

but [11ty does register a bin](https://github.com/11ty/eleventy/blob/main/package.json#L21) so when we're in a node script context that will be on the path and we can just use that instead

we need to use that because of how nodejs is provisioned in our build environment, the npx executable isn't linked automatically at the moment

I guess the benefit that 11ty has of using `npx <packagename>` is that it would work even if you hadn't yet run npm install because npx will install the package if it isn't already - but that's not something we really need with this repo